### PR TITLE
Champion revive, attack and death.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>14</maven.compiler.source>
-        <maven.compiler.target>14</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <javafx.version>16</javafx.version>
         <javafx.maven.plugin.version>0.0.6</javafx.maven.plugin.version>
     </properties>

--- a/src/main/java/lol/client/ai/RandomAI.java
+++ b/src/main/java/lol/client/ai/RandomAI.java
@@ -31,9 +31,18 @@ public class RandomAI extends AIBase {
     // First check if a champion needs to be revived.
     arena.teamOf(teamID).forEachChampion((champion, id) -> {
       if (!champion.isAlive()){
-        turn.registerAction(new Revive(teamID, id, 0, 0));
+        turn.registerAction(new Revive(teamID, id, (int) (Math.random()*9), (int) (Math.random()*9)));
       }
     });
+    // Try to attack ennemies next.
+    arena.teamOf(teamID).forEachChampion((champion, id) ->
+      battlefield.visitAdjacent(champion.x(), champion.y(), champion.attackRange(), new TileVisitor(){
+        public void visitChampion(Champion otherChampion) {
+          if(arena.teamOf(1-teamID).belongsToTeam(otherChampion)) {
+            turn.registerAction(new Attack(teamID, id, otherChampion.x(), otherChampion.y()));
+          }
+        }
+      }));
     // Try to attack the Nexus next.
     arena.teamOf(teamID).forEachChampion((champion, id) ->
       battlefield.visitAdjacent(champion.x(), champion.y(), champion.attackRange(), new TileVisitor(){

--- a/src/main/java/lol/client/ai/RandomAI.java
+++ b/src/main/java/lol/client/ai/RandomAI.java
@@ -28,7 +28,13 @@ public class RandomAI extends AIBase {
 
   public Turn turn() {
     Turn turn = new Turn();
-    // Try to attack the Nexus first.
+    // First check if a champion needs to be revived.
+    arena.teamOf(teamID).forEachChampion((champion, id) -> {
+      if (!champion.isAlive()){
+        turn.registerAction(new Revive(teamID, id, 0, 0));
+      }
+    });
+    // Try to attack the Nexus next.
     arena.teamOf(teamID).forEachChampion((champion, id) ->
       battlefield.visitAdjacent(champion.x(), champion.y(), champion.attackRange(), new TileVisitor(){
         public void visitNexus(Nexus nexus) {

--- a/src/main/java/lol/game/Arena.java
+++ b/src/main/java/lol/game/Arena.java
@@ -51,9 +51,14 @@ public class Arena {
     }
 
     public void visitRevive(int teamID, int championID, int x, int y) {
-      if(!championsWhoActed.contains(championID)) {
-        if(teams.get(teamID).reviveChampion(championID, x, y)) {
-          championsWhoActed.add(championID);
+      if(phase == Phase.GAME) {
+        if(!championsWhoActed.contains(championID)) {
+          if(teams.get(teamID).reviveChampion(championID, x, y)) {
+            championsWhoActed.add(championID);
+          }
+        }
+        else {
+          System.out.println("Team " + teamID + " tried to move a champion outside a GAME phase.");
         }
       }
     }

--- a/src/main/java/lol/game/Arena.java
+++ b/src/main/java/lol/game/Arena.java
@@ -50,6 +50,14 @@ public class Arena {
       }
     }
 
+    public void visitRevive(int teamID, int championID, int x, int y) {
+      if(!championsWhoActed.contains(championID)) {
+        if(teams.get(teamID).reviveChampion(championID, x, y)) {
+          championsWhoActed.add(championID);
+        }
+      }
+    }
+
     public void visitMove(int teamID, int championID, int x, int y) {
       if(phase == Phase.GAME) {
         if(!championsWhoActed.contains(championID)) {

--- a/src/main/java/lol/game/Battlefield.java
+++ b/src/main/java/lol/game/Battlefield.java
@@ -86,6 +86,12 @@ public class Battlefield {
     return true;
   }
 
+  public void removeChampion(Destructible d, int x, int y) {
+    if (d instanceof Champion && !d.isAlive()) {
+      battlefield[y][x] = Optional.empty(); 
+    }
+  }
+
   // We can place something at (x, y) if:
   //   * The ground tile at (x, y) is walkable.
   //   * No other destructible is present at (x, y).

--- a/src/main/java/lol/game/Champion.java
+++ b/src/main/java/lol/game/Champion.java
@@ -5,6 +5,7 @@ public class Champion extends Destructible {
   private int rangeOfAttack;
   private int damages;
   private int speed;
+  private int deathTimer = 0;
 
   private Champion(String name, int hp, int rangeOfAttack, int damages, int speed) {
     super(hp);
@@ -60,6 +61,14 @@ public class Champion extends Destructible {
       return true;
     }
     return false;
+  }
+
+  public void increaseTimer() {
+    deathTimer = deathTimer + 1;
+  }
+
+  public boolean reachedTimer() {
+    return deathTimer==3;
   }
 
   @Override public String toString() {

--- a/src/main/java/lol/game/Champion.java
+++ b/src/main/java/lol/game/Champion.java
@@ -71,6 +71,10 @@ public class Champion extends Destructible {
     return deathTimer==3;
   }
 
+  public void resetTimer() {
+    deathTimer = 0;
+  }
+
   @Override public String toString() {
     return name();
   }

--- a/src/main/java/lol/game/Destructible.java
+++ b/src/main/java/lol/game/Destructible.java
@@ -33,6 +33,10 @@ public abstract class Destructible {
     return currentHP > 0;
   }
 
+  public void revive() {
+    currentHP = initialHP;
+  }
+
   public void reviveAt(int x, int y) {
     currentHP = initialHP;
     place(x, y);

--- a/src/main/java/lol/game/Team.java
+++ b/src/main/java/lol/game/Team.java
@@ -31,6 +31,10 @@ public class Team {
     }
   }
 
+  public boolean belongsToTeam(Champion champion) {
+    return champions.contains(champion);
+  }
+
   public boolean spawnChampion(int championID, int x, int y) {
     Champion champion = champions.get(championID);
     boolean placed = battlefield.placeAt(champion, x, y);
@@ -40,15 +44,21 @@ public class Team {
     return placed;
   }
 
+  public void removeChampion(Destructible d ,int x ,int y) {
+    battlefield.removeChampion(d, x, y);
+  }
+
   public boolean reviveChampion(int championID ,int x ,int y) {
     Champion champion = champions.get(championID);
     boolean revived = false;
     if(champion.reachedTimer()) {
-      revived = battlefield.moveTo(champion, x, y);
+      revived = battlefield.placeAt(champion, x, y);
       champion.revive();
+      champion.resetTimer();
     }
     else {
       champion.increaseTimer();
+      revived = true;
     }
     if(!revived && logInvalidMove) {
       System.out.println("Invalid respawn position of champion " + champion.name());
@@ -74,6 +84,7 @@ public class Team {
     battlefield.visit(x, y, new TileVisitor(){
       @Override public void visitDestructible(Destructible d) {
         attacked[0] = champion.attack(d);
+        removeChampion(d, x ,y);
       }
     });
     if(!attacked[0]) {

--- a/src/main/java/lol/game/Team.java
+++ b/src/main/java/lol/game/Team.java
@@ -40,6 +40,22 @@ public class Team {
     return placed;
   }
 
+  public boolean reviveChampion(int championID ,int x ,int y) {
+    Champion champion = champions.get(championID);
+    boolean revived = false;
+    if(champion.reachedTimer()) {
+      revived = battlefield.moveTo(champion, x, y);
+      champion.revive();
+    }
+    else {
+      champion.increaseTimer();
+    }
+    if(!revived && logInvalidMove) {
+      System.out.println("Invalid respawn position of champion " + champion.name());
+    }
+    return revived;
+  }
+
   public boolean moveChampion(int championID, int x, int y) {
     Champion champion = champions.get(championID);
     boolean moved = false;

--- a/src/main/java/lol/game/action/ActionVisitor.java
+++ b/src/main/java/lol/game/action/ActionVisitor.java
@@ -2,6 +2,7 @@ package lol.game.action;
 
 public interface ActionVisitor {
   public void visitSpawn(int teamID, int championID, int x, int y);
+  public void visitRevive(int teamID,int championID, int x, int y);
   public void visitMove(int teamID, int championID, int x, int y);
   public void visitAttack(int teamID, int championID, int x, int y);
   public void visitChampionSelect(int teamID, String championName);

--- a/src/main/java/lol/game/action/Revive.java
+++ b/src/main/java/lol/game/action/Revive.java
@@ -1,0 +1,15 @@
+package lol.game.action;
+
+import lol.game.*;
+import java.io.Serializable;
+
+public class Revive extends ChampionAction implements Serializable {
+
+  public Revive(int teamID, int championID, int x, int y) {
+    super(teamID, championID, x, y);
+  }
+
+  public void accept(ActionVisitor visitor) {
+    visitor.visitRevive(teamID, championID, x, y);
+  }
+}


### PR DESCRIPTION
Added the ability to revive fallen champions after 3 turns. The number of turns can be changed. The position where the champion is being revived is random, but can be changed later by modifying two parameters. Reviving is done before any other action.

Added the ability to attack enemy champions. This was needed to be able to revive the champions, because if no champions die no champions can be revived. Attacking other champions is done before attacking the nexus or moving if possible.

The modifications also allow to remove dead corpses from the field as soon as they die. This was needed in order not to overload the battlefield with useless corpses.